### PR TITLE
setting refresh-token before setting project

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ async function run() {
         core.addPath(akkaBin);
 
         console.log(`Configuring akka CLI...`);
-        await exec.exec(`akka config set project ${projectId}`);
         await exec.exec(`akka config set refresh-token ${token}`);
+        await exec.exec(`akka config set project ${projectId}`);
         await exec.exec(`akka auth container-registry configure --disable-prompt`);
     } catch (error) {
         core.setFailed(error.message);


### PR DESCRIPTION
The current order of operations (after installing the `akka` cli tool) is

- set the project 
- set the refresh token

Unfortunately, this results in an error

```
Error: the Akka CLI lacks authentication (use 'akka auth login' to connect)
```

Because the project can't be set _before_ the authentication.

Swapping these operations around fixes this (I think).
